### PR TITLE
Potential fix for code scanning alert no. 29: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/Websites/bugs.webkit.org/PrettyPatch/PrettyPatch_test.rb
+++ b/Websites/bugs.webkit.org/PrettyPatch/PrettyPatch_test.rb
@@ -37,7 +37,7 @@ class PrettyPatch_test < Test::Unit::TestCase
         result = nil
         patch_uri = get_patch_uri(id)
         begin
-            result = open(patch_uri) { |f| result = f.read }
+            result = URI.open(patch_uri) { |f| result = f.read }
         rescue => exception
             assert(false, "Fail to get patch " + patch_uri)
         end


### PR DESCRIPTION
Potential fix for [https://github.com/GloWE3/raindrop-space-happiness/security/code-scanning/29](https://github.com/GloWE3/raindrop-space-happiness/security/code-scanning/29)

To fix the problem, we should replace the use of `Kernel.open` with a safer alternative that does not have the same vulnerability. Specifically, we can use `URI.open` from the `open-uri` library, which is designed for opening URLs and does not have the same security risks as `Kernel.open`. This change will ensure that the functionality remains the same while mitigating the security risk.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Replaces the use of `Kernel.open` with `URI.open` to address a code scanning alert related to potential security vulnerabilities.